### PR TITLE
Added recursive reference counting protection and more test cases

### DIFF
--- a/memory/sizeof_test.go
+++ b/memory/sizeof_test.go
@@ -13,6 +13,7 @@ type S struct {
 	u  []uint64
 	ua [8]uint64
 	ch chan int
+	i  interface{}
 }
 
 func rSizeof(o interface{}) uint64 {
@@ -31,6 +32,28 @@ func TestSizeOf(t *testing.T) {
 	s = S{m: map[int32]uint32{1: 1}}
 	if sz := Sizeof(s); sz != esz+8 /*sizeof(uint32) * 2*/ {
 		t.Fatalf(`Sizeof(S{m: map[int32]uint32{1: 1}}) != Sizeof(S{}) + 8, expected %d, got %d`, esz+8, sz)
+	}
+
+	s = S{p: &s}
+	if sz := Sizeof(&s); sz != esz+8 /*sizeof(uint32) * sizeof(ptr)*/ {
+		t.Fatalf(`Sizeof(S{p: &s}) != Sizeof(S{}), expected %d, got %d`, esz+8, sz)
+	}
+
+	m := map[int32]S{1: S{}}
+	if sz := Sizeof(m); sz != esz+12 /*sizeof(uint32) + sizeof(mapHeader)*/ {
+		t.Fatalf(`Sizeof(map[int32]S{1: S{}}) != Sizeof(S{}) + 12, expected %d, got %d`, esz+12, sz)
+	}
+
+	if sz := Sizeof(S{p: &S{}}); sz != esz*2 {
+		t.Fatalf(`Sizeof(S{p:&S{}}) != Sizeof(S{}) *2, expected %d, got %d`, esz*2, sz)
+	}
+
+	if sz := Sizeof([...]S{S{}}); sz != esz {
+		t.Fatalf(`Sizeof([...]S{S{}}) != Sizeof(S{}), expected %d, got %d`, esz, sz)
+	}
+
+	if sz := Sizeof([]S{S{}}); sz != esz+24 {
+		t.Fatalf(`Sizeof([...]S{S{}}) != Sizeof(S{}), expected %d, got %d`, esz, sz)
 	}
 
 	if sz := Sizeof("test"); sz != stringSize+4 {


### PR DESCRIPTION
SizeOf currently fails on any self-referential data structures. This change adds reference tracking to the SizeOf method so that these data structures are properly counted.

In addition, more test cases were added to achieve 100% test coverage of the SizeOf method.