### PR TITLE
Modified SizeOf to use an internal stack instead of recursion

### DIFF
--- a/memory/sizeof_test.go
+++ b/memory/sizeof_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 )
 
+var (
+	sliceSize  = uint64(reflect.TypeOf(reflect.SliceHeader{}).Size())
+	stringSize = uint64(reflect.TypeOf(reflect.StringHeader{}).Size())
+)
+
 type S struct {
 	a  int
 	s  string
@@ -53,10 +58,24 @@ func TestSizeOf(t *testing.T) {
 	}
 
 	if sz := Sizeof([]S{S{}}); sz != esz+24 {
-		t.Fatalf(`Sizeof([...]S{S{}}) != Sizeof(S{}), expected %d, got %d`, esz, sz)
+		t.Fatalf(`Sizeof([]S{S{}}) != Sizeof(S{}), expected %d, got %d`, esz+24, sz)
 	}
 
 	if sz := Sizeof("test"); sz != stringSize+4 {
 		t.Fatalf(`Sizeof("test") != stringSize + 4, expected %d, got %d`, stringSize+4, sz)
+	}
+
+	var sp *S
+	for i := 0; i < 10000; i++ {
+		sp = &S{p: sp}
+	}
+	if sz := Sizeof(*sp); sz != esz*10000 {
+		t.Fatalf(`Sizeof(*sp) != Sizeof(S{}) * 10000, expected %d, got %d`, esz*10000, sz)
+	}
+}
+
+func BenchmarkSizeof(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Sizeof(S{})
 	}
 }


### PR DESCRIPTION
Lots of changes here:

- Uses an internal stack instead of recursing, no more risk of stack overflows. (Yes, I actually had this happen in production)
- Removes need for `fromStruct` property by sizing structs at the element level, this has similar performance characteristics. In the future the size of simple (AKA native type) structs could be cached. This change should also make sizing more accurate with pointer references to struct members, as before a struct member with an external pointer would be double counted.
- Pools internal stacks: About 80% of benchmark time was spent allocating, pooling reduces this significantly.

One nice simplification as a result of these changes is that string/slice headers are implicitly counted, removing that special case code. Also, in general there should no longer be any possibility of recoverable panics.